### PR TITLE
Added some tests and some code changes to pass

### DIFF
--- a/rest-api-sdk/src/main/java/com/paypal/base/DefaultHttpConnection.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/DefaultHttpConnection.java
@@ -84,7 +84,14 @@ public class DefaultHttpConnection extends HttpConnection {
 		setRequestMethodViaJreBugWorkaround(this.connection, config.getHttpMethod());
 		this.connection.setConnectTimeout(this.config.getConnectionTimeout());
 		this.connection.setReadTimeout(this.config.getReadTimeout());
-		
+		switch (config.getInstanceFollowRedirects()) {
+			case NO_DO_NOT_FOLLOW_REDIRECT:
+				connection.setInstanceFollowRedirects(false);
+				break;
+			case YES_FOLLOW_REDIRECT:
+				connection.setInstanceFollowRedirects(true);
+				break;
+		}
 	}
 
 	 /**

--- a/rest-api-sdk/src/main/java/com/paypal/base/GoogleAppEngineHttpConnection.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/GoogleAppEngineHttpConnection.java
@@ -72,6 +72,14 @@ public class GoogleAppEngineHttpConnection extends HttpConnection {
 		}
 		this.connection.setConnectTimeout(this.config.getConnectionTimeout());
 		this.connection.setReadTimeout(this.config.getReadTimeout());
+		switch (config.getInstanceFollowRedirects()) {
+			case NO_DO_NOT_FOLLOW_REDIRECT:
+				connection.setInstanceFollowRedirects(false);
+				break;
+			case YES_FOLLOW_REDIRECT:
+				connection.setInstanceFollowRedirects(true);
+				break;
+		}
 	}
 
 	@Override

--- a/rest-api-sdk/src/main/java/com/paypal/base/HttpConfiguration.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/HttpConfiguration.java
@@ -78,6 +78,17 @@ public class HttpConfiguration {
 	private String httpMethod;
 
 	/**
+	 * Whether 3xx redirects whould be followed.  Default is true to preserve existing behavior
+	 */
+	private FollowRedirect followRedirects = FollowRedirect.DEFAULT;
+
+	enum FollowRedirect {
+		YES_FOLLOW_REDIRECT,
+		NO_DO_NOT_FOLLOW_REDIRECT,
+		DEFAULT // use whatever was already configured for static followRedirects in HttpURLConnection class
+	}
+
+	/**
 	 * HTTP Content Type value, defaulted to 'application/x-www-form-urlencoded'
 	 * @deprecated Set Content-Type in HTTP Headers property of {@link com.paypal.base.rest.APIContext}
 	 */
@@ -326,6 +337,16 @@ public class HttpConfiguration {
 	 */
 	public void setHttpMethod(String httpMethod) {
 		this.httpMethod = httpMethod;
+	}
+
+	// Gets whether HTTP redirects (requests with response code 3xx) should be automatically followed
+	public FollowRedirect getInstanceFollowRedirects() {
+		return followRedirects;
+	}
+
+	// Sets whether HTTP redirects (requests with response code 3xx) should be automatically followed
+	public void setInstanceFollowRedirects(FollowRedirect followRedirects) {
+		this.followRedirects = followRedirects;
 	}
 
 	/**

--- a/rest-api-sdk/src/main/java/com/paypal/base/HttpConnection.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/HttpConnection.java
@@ -128,10 +128,18 @@ public abstract class HttpConnection {
 					}
 
 					// FAILURE
-					reader = new BufferedReader(new InputStreamReader(
-							connection.getInputStream(),
-							Constants.ENCODING_FORMAT));
-					errorResponse = read(reader);
+					InputStream responseStream = null;
+					if (responseCode >= 400) {
+						responseStream = connection.getErrorStream();
+					} else if (responseCode >= 200 && responseCode < 400) {
+						responseStream = connection.getInputStream();
+					}
+					if (responseStream != null) {
+						reader = new BufferedReader(new InputStreamReader(
+								responseStream,
+								Constants.ENCODING_FORMAT));
+						errorResponse = read(reader);
+					}
 					String msg = "Response code: " + responseCode + "\tError response: " + errorResponse;
 
 					if (responseCode >= 300 && responseCode < 500) {

--- a/rest-api-sdk/src/test/java/com/paypal/base/HttpConnectionTest.java
+++ b/rest-api-sdk/src/test/java/com/paypal/base/HttpConnectionTest.java
@@ -9,11 +9,15 @@ import java.net.MalformedURLException;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.ExpectedExceptions;
 import org.testng.annotations.Test;
 
+import com.paypal.base.HttpConfiguration.FollowRedirect;
 import com.paypal.base.exception.ClientActionRequiredException;
 import com.paypal.base.exception.HttpErrorException;
 import com.paypal.base.exception.InvalidResponseDataException;
+
+import static com.paypal.base.HttpConfiguration.FollowRedirect.NO_DO_NOT_FOLLOW_REDIRECT;
 
 public class HttpConnectionTest {
 	HttpConnection connection;
@@ -52,6 +56,42 @@ public class HttpConnectionTest {
 		connection.createAndconfigureHttpConnection(httpConfiguration);
 		String response = connection.execute("url", "payload", null);
 		Assert.assertTrue(response.contains("<ack>Failure</ack>"));
+	}
+
+	@Test(expectedExceptions = HttpErrorException.class,
+			expectedExceptionsMessageRegExp = "Response code: 500\tError response: Internal server error..*")
+	public void Http500Test() throws InvalidResponseDataException,
+			HttpErrorException, ClientActionRequiredException, IOException,
+			InterruptedException {
+		httpConfiguration
+				.setEndPointUrl("https://svcs.sandbox.paypal.com/AdaptivePayments");
+		connection.createAndconfigureHttpConnection(httpConfiguration);
+		connection.execute("url", "payload", null);
+	}
+
+	@Test(expectedExceptions = ClientActionRequiredException.class,
+			expectedExceptionsMessageRegExp = ".*esponse code: 302.*")
+	public void Http3xxTest() throws InvalidResponseDataException,
+			HttpErrorException, ClientActionRequiredException, IOException,
+			InterruptedException {
+		httpConfiguration.setInstanceFollowRedirects(NO_DO_NOT_FOLLOW_REDIRECT);
+		httpConfiguration
+				.setEndPointUrl("https://www.sandbox.paypal.com/wdfunds");
+		connection.createAndconfigureHttpConnection(httpConfiguration);
+		connection.execute("url", "payload", null);
+	}
+
+	// Expecting this test to have a certificate issue that prevents connection
+	// Example: unable to find valid certification path to requested target
+	@Test(expectedExceptions = HttpErrorException.class,
+			expectedExceptionsMessageRegExp = "Response code: -1\tError response: .+")
+	public void connectionFailureTest() throws InvalidResponseDataException,
+			HttpErrorException, ClientActionRequiredException, IOException,
+			InterruptedException {
+		httpConfiguration
+				.setEndPointUrl("https://example.com/AdaptivePayments/ConvertCurrency");
+		connection.createAndconfigureHttpConnection(httpConfiguration);
+		connection.execute("url", "payload", null);
 	}
 
 	@AfterClass


### PR DESCRIPTION
There were still some issues about reading the InputStream
at the wrong time and using the ErrorStream for the cases
where status code was greater than or equal to 400

I added a test that should have a certificate error that prevents connection and has response code = -1

I added a test that should get a 500 response and trigger an HttpErrorException where response code = 500

I added a test that should get a 302 response and trigger a ClientActionRequiredException with the response code 302

For the 302 test I had to add a feature to allow disabling redirects in the PayPal HttpConnection.  To do this I used an enum instead of boolean so we can preserve the default behavior by default, and that behavior is to use whatever was set on the HttpURLConnection class (static). 

Apologies for making the one line change a bit more complicated, but I felt that these tests are important, and getting them to pass was worth the risk of adding more code.